### PR TITLE
Add improved components for observations and rewards

### DIFF
--- a/core/obs/data_collector.py
+++ b/core/obs/data_collector.py
@@ -1,98 +1,83 @@
 import json
 
-""" 
-Description: This script contains the implementation of the DataCollector class, which is responsible for collecting data from the SUMO traffic simulation.
-path: TSCMARL/marl_setup/data_collection.py
-"""
-
 class DataCollector:
+    """Utility class for fetching raw traffic metrics from SUMO."""
+
     def __init__(self, tls_id, config, sumo_interface, logger=None):
         self.id = tls_id
         self.config = config
         self.logger = logger
         self.sumo_interface = sumo_interface
-        self.detectors = self.initialize_detectors()
-        self.feature_means = {}
-        self.feature_stds = {}
+        self.detector_config = self.config.get('detectors', {})
         self.metrics = self.config.get('metrics', {})
         self.obs_metrics = self.metrics.get('obs_metrics', [])
-        self.action_type = self.metrics['action_type']
-        self.detector_config = self.config.get('detectors', {})
+        self.action_type = self.metrics.get('action_type', '')
 
+        self.detectors = self._init_detectors()
+
+    def _init_detectors(self):
         detectors = []
         controlled_links = self.sumo_interface.trafficlight.getControlledLinks(self.id)
         in_lanes = {link[0] for links in controlled_links for link in links}
-        self.detectors_enabled = self.detector_config.get('enabled', [])
-
-        for detector_type in self.detectors_enabled:
-            detector_prefix = self.detector_config['detector_prefix'][detector_type]
-            detectors.extend(f"{detector_prefix}_{lane}" for lane in in_lanes)
+        enabled = self.detector_config.get('enabled', [])
+        pref = self.detector_config.get('detector_prefix', {})
+        for detector_type in enabled:
+            prefix = pref[detector_type]
+            detectors.extend(f"{prefix}_{lane}" for lane in in_lanes)
         return detectors
 
+    # ------------------------------------------------------------------
+    def get_queue_length(self):
+        return self.collect_traffic_metrics().get('queue_length', 0.0)
+
+    def get_waiting_time(self):
+        return self.collect_traffic_metrics().get('waiting_time', 0.0)
+
+    # Backwards compatibility
+    def get_wait_time(self):
+        return self.get_waiting_time()
+
+    def get_emergency_vehicle_count(self):
+        return 0
+
+    def get_pedestrian_button_pressed(self):
+        return False
+
+    # ------------------------------------------------------------------
     def collect_traffic_metrics(self):
-        """
-        Collect data from enabled detectors, return a dictionary of the collected data.
-        """
         aggregated_data = {metric: 0.0 for metric in self.obs_metrics}
         mean_speed_count = 0
         occupancy_count = 0
 
         for detector_id in self.detectors:
             if detector_id.startswith('e1det_'):
-
                 if 'vehicle_count' in self.obs_metrics:
-                    throughput = self.sumo_interface.inductionloop.getLastStepVehicleNumber(detector_id)
-                    aggregated_data['throughput'] += throughput
+                    aggregated_data['vehicle_count'] += self.sumo_interface.inductionloop.getLastStepVehicleNumber(detector_id)
                 if 'mean_speed' in self.obs_metrics:
                     mean_speed = self.sumo_interface.inductionloop.getLastStepMeanSpeed(detector_id)
                     if mean_speed >= 0:
                         aggregated_data['mean_speed'] += mean_speed
                         mean_speed_count += 1
                 if 'occupancy' in self.obs_metrics:
-                    occupancy = self.sumo_interface.inductionloop.getLastStepOccupancy(detector_id)
-                    aggregated_data['occupancy'] += occupancy
+                    aggregated_data['occupancy'] += self.sumo_interface.inductionloop.getLastStepOccupancy(detector_id)
                     occupancy_count += 1
                 if 'waiting_time' in self.obs_metrics:
                     vehicle_ids = self.sumo_interface.inductionloop.getLastStepVehicleIDs(detector_id)
                     vehicle_data = self.sumo_interface.inductionloop.getVehicleData(detector_id)
-                    for veh_id, veh_length, entry_time, exit_time, v_type in vehicle_data:
+                    for veh_id, _, entry_time, exit_time, _ in vehicle_data:
                         if veh_id in vehicle_ids:
-                            waiting_time = exit_time - entry_time
-                            aggregated_data['waiting_time'] += waiting_time
-
+                            aggregated_data['waiting_time'] += exit_time - entry_time
             elif detector_id.startswith('e2det_'):
-                # Lane Area Detectors (Incoming Lanes)
                 if 'queue_length' in self.obs_metrics:
-                    jam_length = self.sumo_interface.lanearea.getJamLengthVehicle(detector_id)
-                    aggregated_data['queue_length'] += jam_length
-
+                    aggregated_data['queue_length'] += self.sumo_interface.lanearea.getJamLengthVehicle(detector_id)
                 if 'queue_length_in_meters' in self.obs_metrics:
-                    jam_length_meters = self.sumo_interface.lanearea.getJamLengthMeters(detector_id)
-                    aggregated_data['queue_length_in_meters'] += jam_length_meters
-
+                    aggregated_data['queue_length_in_meters'] += self.sumo_interface.lanearea.getJamLengthMeters(detector_id)
                 if 'halt_count' in self.obs_metrics:
-                    halt_count = self.sumo_interface.lanearea.getLastStepHaltingNumber(detector_id)
-                    aggregated_data['halt_count'] += halt_count
+                    aggregated_data['halt_count'] += self.sumo_interface.lanearea.getLastStepHaltingNumber(detector_id)
 
-        # Calculate averages if counts are greater than zero
-        if mean_speed_count > 0:
+        if mean_speed_count > 0 and 'mean_speed' in aggregated_data:
             aggregated_data['mean_speed'] /= mean_speed_count
-        if occupancy_count > 0:
+        if occupancy_count > 0 and 'occupancy' in aggregated_data:
             aggregated_data['occupancy'] /= occupancy_count
 
         return aggregated_data
-
-
-    def initialize_detectors(self):
-        """
-        Initialize detectors based on the configuration.
-        """
-        detectors = []
-        controlled_links = self.sumo_interface.trafficlight.getControlledLinks(self.id)
-        in_lanes = {link[0] for links in controlled_links for link in links}
-        self.detectors_enabled = self.detector_config.get('enabled', [])
-
-        for detector_type in self.detectors_enabled:
-            detector_prefix = self.detector_config['detector_prefix'][detector_type]
-            detectors.extend(f"{detector_prefix}_{lane}" for lane in in_lanes)
-        return detectors

--- a/core/obs/lanearea.py
+++ b/core/obs/lanearea.py
@@ -1,0 +1,44 @@
+import numpy as np
+import gymnasium as gym
+from .base import BaseObservationBuilder
+from ..registry import register_builder
+
+
+@register_builder("lanearea")
+class LaneAreaBuilder(BaseObservationBuilder):
+    """Collects metrics from e2 lane area detectors."""
+
+    def __init__(self, tls_id, cfg, traci_if, logger=None):
+        super().__init__(tls_id, cfg, traci_if, logger)
+        self._metrics = cfg["metrics"]["obs_metrics"]
+        self._init_detectors()
+
+    def _init_detectors(self):
+        lanes = {lnk[0] for links in self.traci.trafficlight.getControlledLinks(self.id)
+                          for lnk in links}
+        pref = self.cfg["detectors"]["detector_prefix"]
+        enabled = self.cfg["detectors"]["enabled"]
+        self.detectors = [f"{pref[tp]}_{ln}" for tp in enabled for ln in lanes if tp.startswith("e2")]
+
+    # ------------------------------------------------------------
+    def space(self):
+        low = np.full(len(self._metrics), -np.inf, dtype=np.float32)
+        high = np.full(len(self._metrics), np.inf, dtype=np.float32)
+        return gym.spaces.Box(low=low, high=high, dtype=np.float32)
+
+    def __call__(self):
+        agg = dict.fromkeys(self._metrics, 0.0)
+        count_occ = 0
+        for det_id in self.detectors:
+            if "queue_length" in agg:
+                agg["queue_length"] += self.traci.lanearea.getJamLengthVehicle(det_id)
+            if "queue_length_in_meters" in agg:
+                agg["queue_length_in_meters"] += self.traci.lanearea.getJamLengthMeters(det_id)
+            if "halt_count" in agg:
+                agg["halt_count"] += self.traci.lanearea.getLastStepHaltingNumber(det_id)
+            if "occupancy" in agg:
+                agg["occupancy"] += self.traci.lanearea.getLastStepOccupancy(det_id)
+                count_occ += 1
+        if count_occ and "occupancy" in agg:
+            agg["occupancy"] /= count_occ
+        return agg

--- a/core/obs/multi_entry_exit.py
+++ b/core/obs/multi_entry_exit.py
@@ -1,0 +1,50 @@
+import numpy as np
+import gymnasium as gym
+from .base import BaseObservationBuilder
+from ..registry import register_builder
+
+
+@register_builder("multi_entry_exit")
+class MultiEntryExitBuilder(BaseObservationBuilder):
+    """Combine induction loop and lane area metrics."""
+
+    def __init__(self, tls_id, cfg, traci_if, logger=None):
+        super().__init__(tls_id, cfg, traci_if, logger)
+        self._metrics = cfg["metrics"]["obs_metrics"]
+        self._init_detectors()
+
+    def _init_detectors(self):
+        lanes = {lnk[0] for links in self.traci.trafficlight.getControlledLinks(self.id)
+                          for lnk in links}
+        pref = self.cfg["detectors"]["detector_prefix"]
+        enabled = self.cfg["detectors"]["enabled"]
+        self.detectors = [f"{pref[tp]}_{ln}" for tp in enabled for ln in lanes]
+
+    def space(self):
+        low = np.full(len(self._metrics), -np.inf, dtype=np.float32)
+        high = np.full(len(self._metrics), np.inf, dtype=np.float32)
+        return gym.spaces.Box(low=low, high=high, dtype=np.float32)
+
+    def __call__(self):
+        agg = dict.fromkeys(self._metrics, 0.0)
+        traci = self.traci
+        count_speed = 0
+        for det_id in self.detectors:
+            if det_id.startswith("e1det_"):
+                if "vehicle_count" in agg:
+                    agg["vehicle_count"] += traci.inductionloop.getLastStepVehicleNumber(det_id)
+                if "mean_speed" in agg:
+                    spd = traci.inductionloop.getLastStepMeanSpeed(det_id)
+                    if spd >= 0:
+                        agg["mean_speed"] += spd
+                        count_speed += 1
+                if "occupancy" in agg:
+                    agg["occupancy"] += traci.inductionloop.getLastStepOccupancy(det_id)
+            elif det_id.startswith("e2det_"):
+                if "queue_length" in agg:
+                    agg["queue_length"] += traci.lanearea.getJamLengthVehicle(det_id)
+                if "halt_count" in agg:
+                    agg["halt_count"] += traci.lanearea.getLastStepHaltingNumber(det_id)
+        if count_speed and "mean_speed" in agg:
+            agg["mean_speed"] /= count_speed
+        return agg

--- a/core/obs_builder.py
+++ b/core/obs_builder.py
@@ -1,6 +1,9 @@
 # marl_tsc/core/obs_builder.py
 from abc import ABC, abstractmethod
 import numpy as np, gymnasium as gym
+from .obs.induction_loop import InductionLoopBuilder
+from .obs.lanearea import LaneAreaBuilder
+from .obs.multi_entry_exit import MultiEntryExitBuilder
 
 class ObservationBuilder(ABC):
     """Collects raw features for a single traffic-light controller."""
@@ -44,7 +47,10 @@ class FullDetectorSet(ObservationBuilder):
 # ---------- Registry ---------- #
 _registry = {
     "queue_basic": QueueLenWaitTime,
-    "detectors_full": FullDetectorSet
+    "detectors_full": FullDetectorSet,
+    "induction_loop": InductionLoopBuilder,
+    "lanearea": LaneAreaBuilder,
+    "multi_entry_exit": MultiEntryExitBuilder,
 }
 
 def get_builder(name, tlc, cfg):

--- a/core/registry.py
+++ b/core/registry.py
@@ -1,0 +1,22 @@
+"""Simple registry utilities for observation builders."""
+from typing import Dict, Type
+
+_builder_registry: Dict[str, Type] = {}
+
+
+def register_builder(name: str):
+    """Decorator to register an observation builder class."""
+    def deco(cls):
+        _builder_registry[name] = cls
+        return cls
+    return deco
+
+
+def get_builder_cls(name: str):
+    if name not in _builder_registry:
+        raise KeyError(f"Unknown builder {name}")
+    return _builder_registry[name]
+
+
+def available_builders():
+    return list(_builder_registry.keys())

--- a/core/reward_fn.py
+++ b/core/reward_fn.py
@@ -1,0 +1,9 @@
+"""Registry access for reward functions."""
+from .rewards import get_reward_fn, available_rewards, register_reward, RewardFunction
+
+__all__ = [
+    "get_reward_fn",
+    "available_rewards",
+    "register_reward",
+    "RewardFunction",
+]

--- a/core/rewards/__init__.py
+++ b/core/rewards/__init__.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+import abc
+from typing import Dict, Any
+
+class RewardFunction(abc.ABC):
+    """Base interface for computing rewards for a single agent."""
+    def __init__(self, **kwargs: Any):
+        pass
+
+    @abc.abstractmethod
+    def __call__(self, prev_obs: Dict[str, float], curr_obs: Dict[str, float]) -> float:
+        ...
+
+
+class QueueDiffReward(RewardFunction):
+    """Reward negative change in queue length."""
+    metric = "queue_length"
+    def __call__(self, prev_obs: Dict[str, float], curr_obs: Dict[str, float]) -> float:
+        before = prev_obs.get(self.metric, 0.0)
+        after = curr_obs.get(self.metric, 0.0)
+        return -(after - before)
+
+
+class WaitTimeDiffReward(RewardFunction):
+    """Reward reduction in waiting time."""
+    metric = "waiting_time"
+    def __call__(self, prev_obs: Dict[str, float], curr_obs: Dict[str, float]) -> float:
+        before = prev_obs.get(self.metric, 0.0)
+        after = curr_obs.get(self.metric, 0.0)
+        return -(after - before)
+
+
+_registry: Dict[str, type[RewardFunction]] = {
+    "queue_diff": QueueDiffReward,
+    "wait_time_diff": WaitTimeDiffReward,
+}
+
+
+def register_reward(name: str):
+    def deco(cls: type[RewardFunction]):
+        _registry[name] = cls
+        return cls
+    return deco
+
+
+def get_reward_fn(name: str, **kwargs: Any) -> RewardFunction:
+    if name not in _registry:
+        raise KeyError(f"Unknown reward function {name}")
+    return _registry[name](**kwargs)
+
+
+def available_rewards():
+    return list(_registry.keys())


### PR DESCRIPTION
## Summary
- flesh out observation builders using lanearea and loop detectors
- add a simple registry for builders
- rewrite the `DataCollector` for flexible detector metrics
- provide basic reward functions and registry helpers
- expose new observation builders in `obs_builder`

## Testing
- `python -m compileall -q core`
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe0b3e1148331a0d5a3c9cca5db92